### PR TITLE
Add config tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.4"
   - "pypy"
 install:
+  - pip install -U setuptools
   - pip uninstall mock -y
   - python setup.py install
 script: python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,6 @@ python:
   - "3.4"
   - "pypy"
 install:
+  - pip uninstall mock -y
   - python setup.py install
 script: python setup.py test

--- a/liaison/config.py
+++ b/liaison/config.py
@@ -27,12 +27,12 @@ class LiaisonConfig(object):
         self.pool_size = pool_size
         self.sleep = sleep
 
-        if consul_config is type(ConsulConfig):
+        if isinstance(consul_config, ConsulConfig):
             self.consul_config = consul_config
         else:
             self.consul_config = ConsulConfig()
 
-        if sink_config is type(SinkConfig):
+        if isinstance(sink_config, SinkConfig):
             self.sink_config = sink_config
         else:
             self.sink_config = SinkConfig()

--- a/liaison/config.py
+++ b/liaison/config.py
@@ -26,14 +26,17 @@ class LiaisonConfig(object):
         """
         self.pool_size = pool_size
         self.sleep = sleep
-
-        if isinstance(consul_config, ConsulConfig):
+        if isinstance(consul_config, type(None)):
+            self.consul_config = ConsulConfig()
+        elif isinstance(consul_config, ConsulConfig):
             self.consul_config = consul_config
         else:
             raise Exception(
                 "LiaisonConfig | Bad consul_config parameter. Invalid type")
 
-        if isinstance(sink_config, SinkConfig):
+        if isinstance(sink_config, type(None)):
+            self.sink_config = SinkConfig()
+        elif isinstance(sink_config, SinkConfig):
             self.sink_config = sink_config
         else:
             raise Exception(

--- a/liaison/config.py
+++ b/liaison/config.py
@@ -30,12 +30,14 @@ class LiaisonConfig(object):
         if isinstance(consul_config, ConsulConfig):
             self.consul_config = consul_config
         else:
-            self.consul_config = ConsulConfig()
+            raise Exception(
+                "LiaisonConfig | Bad consul_config parameter. Invalid type")
 
         if isinstance(sink_config, SinkConfig):
             self.sink_config = sink_config
         else:
-            self.sink_config = SinkConfig()
+            raise Exception(
+                "LiaisonConfig | Bad sink_config parameter. Invalid type")
 
 
 class ConsulConfig(object):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-python-consul
-statsd
+python-consul>=0.4.7
+statsd>=3.2.1
 argparse
 six

--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,13 @@ import sys
 
 tests_require = ['pytest', 'pytest-flake8', 'flake8']
 
+if sys.version < '3.3':
+    tests_require.append('mock>=1.3.0')
 if sys.version < '3':
-    tests_require.append('unittest2')
+    tests_require.append('unittest2>=1.1.0')
 
 setup(name='liaison',
-      version='0.3.1',
+      version='0.4.0_rc1',
       description='A small daemon that collects service health information '
                   'from consul and sends it to a TSDB',
       url='http://github.com/cruatta/liaison',
@@ -16,7 +18,8 @@ setup(name='liaison',
       scripts=['bin/liaison'],
       package_data={'liaison': ['README.md', 'LICENSE.txt']},
       license='MIT',
-      install_requires=['python-consul', 'statsd', 'argparse', 'six'],
+      install_requires=['python-consul>=0.4.7', 'statsd>=3.2.1', 'argparse',
+                        'six'],
       tests_require=tests_require,
       setup_requires=['pytest-runner'],
       )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ if sys.version < '3':
     tests_require.append('unittest2>=1.1.0')
 
 setup(name='liaison',
-      version='0.4.0_rc1',
+      version='0.4.0',
       description='A small daemon that collects service health information '
                   'from consul and sends it to a TSDB',
       url='http://github.com/cruatta/liaison',

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -44,12 +44,14 @@ class ConfigTests(unittest.TestCase):
             'consul': {},
             'sink': {
                 'options': {
-                    'host': '127.0.0.1'
+                    'host': '192.168.0.1',
+                    'port': 8135
                 }
             }
         }
 
         lc = load_config('')
+        self.assertEqual(lc.sink_config.opts.args(), ['192.168.0.1', 8135])
 
     @mock.patch('liaison.config.json.load')
     @mock.patch('liaison.config.open')
@@ -64,7 +66,6 @@ class ConfigTests(unittest.TestCase):
             }
         }
         try:
-            lc = load_config('')
+            load_config('')
         except Exception as e:
             self.assertEqual(e.message, 'Invalid Sink configuration.')
-

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -19,7 +19,7 @@ class ConfigTests(unittest.TestCase):
         pass
 
     @mock.patch('liaison.config.json.load')
-    @mock.patch('liaison.config.open')
+    @mock.patch('liaison.config.open', create=True)
     def test_load_config(self, mock_open, mock_load):
         mock_load.return_value = {
             'pool_size': 3,
@@ -36,7 +36,7 @@ class ConfigTests(unittest.TestCase):
         self.assertIsInstance(lc.sink_config, SinkConfig)
 
     @mock.patch('liaison.config.json.load')
-    @mock.patch('liaison.config.open')
+    @mock.patch('liaison.config.open', create=True)
     def test_load_config_with_options(self, mock_open, mock_load):
         mock_load.return_value = {
             'pool_size': 3,
@@ -66,7 +66,7 @@ class ConfigTests(unittest.TestCase):
         })
 
     @mock.patch('liaison.config.json.load')
-    @mock.patch('liaison.config.open')
+    @mock.patch('liaison.config.open', create=True)
     def test_load_config_bad_sink_options(self, mock_open, mock_load):
         mock_load.return_value = {
             'pool_size': 3,

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,0 +1,70 @@
+from __future__ import absolute_import
+
+import sys
+from liaison.config import LiaisonConfig, ConsulConfig, SinkConfig, load_config
+
+if sys.version >= '3.3':
+    import unittest
+    import unittest.mock as mock
+elif sys.version >= '3':
+    import unittest
+    import mock
+else:
+    import unittest2 as unittest
+    import mock
+
+
+class ConfigTests(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    @mock.patch('liaison.config.json.load')
+    @mock.patch('liaison.config.open')
+    def test_load_config(self, mock_open, mock_load):
+        mock_load.return_value = {
+            'pool_size': 3,
+            'sleep': 1,
+            'consul': {},
+            'sink': {}
+        }
+        lc = load_config('/tmp/file')
+        mock_open.assert_called_with('/tmp/file')
+        self.assertEqual(lc.pool_size, 3)
+        self.assertEqual(lc.sleep, 1)
+        self.assertIsInstance(lc, LiaisonConfig)
+        self.assertIsInstance(lc.consul_config, ConsulConfig)
+        self.assertIsInstance(lc.sink_config, SinkConfig)
+
+    @mock.patch('liaison.config.json.load')
+    @mock.patch('liaison.config.open')
+    def test_load_config_sink_options(self, mock_open, mock_load):
+        mock_load.return_value = {
+            'pool_size': 3,
+            'sleep': 1,
+            'consul': {},
+            'sink': {
+                'options': {
+                    'host': '127.0.0.1'
+                }
+            }
+        }
+
+        lc = load_config('')
+
+    @mock.patch('liaison.config.json.load')
+    @mock.patch('liaison.config.open')
+    def test_load_config_bad_sink_options(self, mock_open, mock_load):
+        mock_load.return_value = {
+            'pool_size': 3,
+            'sleep': 1,
+            'consul': {},
+            'sink': {
+                'type': 'bad',
+                'options': {}
+            }
+        }
+        try:
+            lc = load_config('')
+        except Exception as e:
+            self.assertEqual(e.message, 'Invalid Sink configuration.')
+

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -80,4 +80,4 @@ class ConfigTests(unittest.TestCase):
         try:
             load_config('')
         except Exception as e:
-            self.assertEqual(e.message, 'Invalid Sink configuration.')
+            self.assertEqual(e, 'Invalid Sink configuration.')

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -80,4 +80,4 @@ class ConfigTests(unittest.TestCase):
         try:
             load_config('')
         except Exception as e:
-            self.assertEqual(e, 'Invalid Sink configuration.')
+            self.assertEqual(str(e), 'Invalid Sink configuration.')

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -37,11 +37,14 @@ class ConfigTests(unittest.TestCase):
 
     @mock.patch('liaison.config.json.load')
     @mock.patch('liaison.config.open')
-    def test_load_config_sink_options(self, mock_open, mock_load):
+    def test_load_config_with_options(self, mock_open, mock_load):
         mock_load.return_value = {
             'pool_size': 3,
             'sleep': 1,
-            'consul': {},
+            'consul': {
+                'consistency': 'stale',
+                'dc': 'dc99'
+            },
             'sink': {
                 'options': {
                     'host': '192.168.0.1',
@@ -52,6 +55,15 @@ class ConfigTests(unittest.TestCase):
 
         lc = load_config('')
         self.assertEqual(lc.sink_config.opts.args(), ['192.168.0.1', 8135])
+        self.assertEqual(lc.consul_config.kwargs(), {
+            'host': '127.0.0.1',
+            'port': 8500,
+            'token': None,
+            'scheme': 'http',
+            'consistency': 'stale',
+            'dc': 'dc99',
+            'verify': True
+        })
 
     @mock.patch('liaison.config.json.load')
     @mock.patch('liaison.config.open')


### PR DESCRIPTION
This fixes a bug in config. 
`if consul_config is type(ConsulConfig)` and `if sink_config is type(SinkConfig)` are both going to fail consistently. isinstance is the correct thing to use.  
