### PR TITLE
Consul tests

### DIFF
--- a/liaison/consul.py
+++ b/liaison/consul.py
@@ -7,7 +7,8 @@ class Consul(object):
     def __init__(self, config):
         """
 
-        :param config:
+        :param config: A ConsulConfig object containing settings for
+        Consul (ConsulAPI)
         :type config: ConsulConfig
         """
         self.api = ConsulAPI(**config.kwargs())

--- a/liaison/consul.py
+++ b/liaison/consul.py
@@ -1,21 +1,24 @@
 from __future__ import absolute_import
-
+from liaison.config import ConsulConfig
 from consul import Consul as ConsulAPI
 
 
 class Consul(object):
     def __init__(self, config):
+        """
+
+        :param config:
+        :type config: ConsulConfig
+        """
         self.api = ConsulAPI(**config.kwargs())
 
     def get_dc(self):
         """
 
-        :return: The datacenter of the agent
+        :return: The datacenter specified for use by the API
         :rtype: str
         """
-        s = self.api.agent.self()
-        dc = s['Config']['Datacenter']
-        return dc
+        return self.api.dc
 
     def get_services(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ if sys.version < '3':
     tests_require.append('unittest2>=1.1.0')
 
 setup(name='liaison',
-      version='0.4.1',
+      version='0.5.0_rc1',
       description='A small daemon that collects service health information '
                   'from consul and sends it to a TSDB',
       url='http://github.com/cruatta/liaison',

--- a/tests/consul_test.py
+++ b/tests/consul_test.py
@@ -23,4 +23,3 @@ class ConsulTests(unittest.TestCase):
         cc = config.ConsulConfig(dc=dc)
         c = consul.Consul(cc)
         self.assertEquals(dc, c.api.dc)
-

--- a/tests/consul_test.py
+++ b/tests/consul_test.py
@@ -1,0 +1,26 @@
+from __future__ import absolute_import
+
+import sys
+from liaison import consul, config
+
+if sys.version >= '3.3':
+    import unittest
+    import unittest.mock as mock
+elif sys.version >= '3':
+    import unittest
+    import mock
+else:
+    import unittest2 as unittest
+    import mock
+
+
+class ConsulTests(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_get_dc(self):
+        dc = 'test'
+        cc = config.ConsulConfig(dc=dc)
+        c = consul.Consul(cc)
+        self.assertEquals(dc, c.api.dc)
+


### PR DESCRIPTION
Adding some unit tests for consul.py. Fixes a bug where get_dc() returns the Agent's DC instead of the API configured DC. 
